### PR TITLE
merge 0.9.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 - unreleased
+    - **Breaking** Rename  `ZonedExtra.FoldType` to `ResolvedFold`, because the
+      Go language forces me to capitalize the field "FoldType" whose type is
+      "FoldType".
+    - **Breaking** Use typesafe types for enums (`findResultType` instead of
+      `uint8`, `FoldType` instead of `uint8`).
+    - **Breaking** Simplify `FoldType`.
+        - Merge `FoldTypeErr` into `FoldTypeNotFound`.
+        - Merge `findResultErr` into `findResultNotFound`.
+    - Regenerate memory benchmarks using Go 1.25.3 and TinyGo 0.39.0.
 - 0.8.0 (2025-10-21, TZDB 2025b)
     - **Breaking** Rename LocalXxx to PlainXxx, following the conventions
       used by more modern timezone libraries (JavaScript Temporal, Python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 # Changelog
 
 - unreleased
-    - **Breaking** Rename  `ZonedExtra.FoldType` to `ResolvedFold`, because the
-      Go language forces me to capitalize the field "FoldType" whose type is
-      "FoldType".
+- 0.9.0 (2025-11-17, TZDB 2025b)
+    - **Breaking** Replace  `ZonedExtra.FoldType` with `ZonedExtra.Resolved`
+      which has the same meaning as `ZonedDateTime.Resolved`.
     - **Breaking** Use typesafe types for enums (`findResultType` instead of
-      `uint8`, `FoldType` instead of `uint8`).
-    - **Breaking** Simplify `FoldType`.
-        - Merge `FoldTypeErr` into `FoldTypeNotFound`.
-        - Merge `findResultErr` into `findResultNotFound`.
+      `uint8`, `ResolvedType` instead of `uint8`).
+    - **Breaking** Remove `ZonedDataTime.ZonedExtra()` that converts
+      `ZonedDateTime` into a `ZonedExtra`.
+        - Use `ZonedExtraFromPlainDateTime()` or `ZonedExtraFromUnixSeconds()`
+          instead.
+        - For compatibility with `AceTime` and `acetimec` libraries. Simplifies
+          the API.
     - Regenerate memory benchmarks using Go 1.25.3 and TinyGo 0.39.0.
 - 0.8.0 (2025-10-21, TZDB 2025b)
     - **Breaking** Rename LocalXxx to PlainXxx, following the conventions

--- a/README.md
+++ b/README.md
@@ -515,12 +515,12 @@ The `ZonedExtra` has the following fields:
 
 ```go
 type ZonedExtra struct {
-  FoldType            uint8  // type of fold (e.g. gap, overlap)
-  StdOffsetSeconds    int32  // STD offset
-  DstOffsetSeconds    int32  // DST offset
-  ReqStdOffsetSeconds int32  // request STD offset
-  ReqDstOffsetSeconds int32  // request DST offset
-  Abbrev              string // abbreviation (e.g. PST, PDT)
+  ResolvedFold        FoldType  // type of fold (e.g. gap, overlap)
+  StdOffsetSeconds    int32     // STD offset
+  DstOffsetSeconds    int32     // DST offset
+  ReqStdOffsetSeconds int32     // request STD offset
+  ReqDstOffsetSeconds int32     // request DST offset
+  Abbrev              string    // abbreviation (e.g. PST, PDT)
 }
 ```
 
@@ -530,8 +530,8 @@ It is created by:
 - `acetime.ZonedExtraFromPlainDateTime(plainDateTime, tz, disambiguate)`
 - `acetime.ZonedDateTime.ZonedExtra()`
 
-The `FoldType` specifies whether the given `PlainDateTime` is within an overlap
-or a gap. It takes 5 values:
+The `ResolvedFold` specifies whether the given `PlainDateTime` is within an
+overlap or a gap. It takes 5 values:
 
 - `FoldTypeErr`: the `ZonedExtra` object is an error indicator, and
   `ZonedExtra.IsError()` returns true

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This library implements the algorithms equivalent to the following libraries:
 - [acetimepy](https://github.com/bxparks/acetimepy) for Python,
 - [acetimec](https://github.com/bxparks/acetimec) for C.
 
-**Version**: 0.8.0 (2025-10-21, TZDB 2025b)
+**Version**: 0.9.0 (2025-11-17, TZDB 2025b)
 
 **Changelog**: [CHANGELOG.md](CHANGELOG.md)
 
@@ -523,7 +523,6 @@ It is created by:
 
 - `acetime.ZonedExtraFromUnixSeconds(unixSeconds, tz)`
 - `acetime.ZonedExtraFromPlainDateTime(plainDateTime, tz, disambiguate)`
-- `acetime.ZonedDateTime.ZonedExtra()`
 
 The `ResolvedFold` specifies whether the given `PlainDateTime` is within an
 overlap or a gap. It takes 5 values:
@@ -538,9 +537,6 @@ The `Abbrev` parameter is the timezone abbreviation that corresponds to the
 given unixSeconds or `PlainDateTime`. For example, for the `America/Los_Angeles`
 time zone, it will be "PST" (Pacific Standard Time) during the winter months,
 and "PDT" (Pacific Daylight Time) during the summer months.
-
-For convenience, `ZonedDateTime` can directly retrieve the corresponding
-`ZonedExtra` object using `ZonedDateTime.ZonedExtra()`.
 
 (TODO: add documentation of the various OffsetSeconds parameters.)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# acetimego - AceTime time zone library for Go and TinyGo
+# acetimego - a tiny time zone library for Go and TinyGo
 
 [![Go Tests](https://github.com/bxparks/acetimego/actions/workflows/verify.yml/badge.svg)](https://github.com/bxparks/acetimego/actions/workflows/verify.yml)
 
@@ -24,8 +24,6 @@ provided in this library:
     - All timezones with transitions for all years defined by the TZDB database,
       from the year 1844 onwards,
     - Consumes  about 72 kB of flash memory.
-- `zonedbtesting`
-    - A small subset of timezones for internal testing purposes.
 
 To reduce RAM memory consumption, the TZDB is parsed and compiled into binary
 data encoded as `const string` variables, which allows the TinyGo compiler to
@@ -76,7 +74,7 @@ import (
 )
 ```
 
-There are 4 database packages which allows the end user to select the range of
+There are 3 database packages which allows the end user to select the range of
 validity of the TZDB, which directly affects the size of the final binary.
 Normally, an application will choose only of the following:
 
@@ -85,7 +83,6 @@ import (
   "github.com/bxparks/acetimego/zonedb2000"
   "github.com/bxparks/acetimego/zonedb2025"
   "github.com/bxparks/acetimego/zonedball"
-  "github.com/bxparks/acetimego/zonedbtesting"
 )
 ```
 
@@ -97,8 +94,6 @@ import (
   kB.
 - `zonedball` contains the entire TZDB, for all timezones, for all years in the
   TZDB from 1844 and onwards. The database size is approximately 72 kB.
-- `zonedbtesting` is used only for testing purposes and contains only a subset
-  of timezones of the world. The database is only 400 bytes.
 
 The `zoneinfo` package:
 
@@ -533,16 +528,16 @@ It is created by:
 The `ResolvedFold` specifies whether the given `PlainDateTime` is within an
 overlap or a gap. It takes 5 values:
 
-- `FoldTypeErr`: the `ZonedExtra` object is an error indicator, and
-  `ZonedExtra.IsError()` returns true
-- `FoldTypeNotFound`: the `PlainDateTime` was outside a valid range. This
-  shouldn't happen (TODO: Remove?)
+- `FoldTypeNotFound`: an internal error occurred or the `PlainDateTime` was
+  outside a valid range (`ZonedExtra.IsError()` returns `true`)
 - `FoldTypeExact`: the `PlainDateTime` corresponds to a unique date-time value
 - `FoldTypeGap`: the `PlainDateTime` falls in a gap
 - `FoldTypeOverlap`: the `PlainDateTime` falls in an overlap.
 
 The `Abbrev` parameter is the timezone abbreviation that corresponds to the
-given unixSeconds or `PlainDateTime`.
+given unixSeconds or `PlainDateTime`. For example, for the `America/Los_Angeles`
+time zone, it will be "PST" (Pacific Standard Time) during the winter months,
+and "PDT" (Pacific Daylight Time) during the summer months.
 
 For convenience, `ZonedDateTime` can directly retrieve the corresponding
 `ZonedExtra` object using `ZonedDateTime.ZonedExtra()`.
@@ -551,18 +546,17 @@ For convenience, `ZonedDateTime` can directly retrieve the corresponding
 
 ## Bugs And Limitations
 
-`acetimgo` does not support access to a monotonic clock of the underlying
-system. The sole purpose of acetimego is to support timezones and date-times in
-the Gregorian calendar system.
-
-`acetimego` does not support the `time.Duration` object. The difference between
-two `acetime.Time` values can be represented as an `int64`.
-
-`acetimego` does not support date arithmetics such as adding days or months.
-
-`acetimego` does not support generalized formatting of the `ZonedDateTime`
-object similar to `time.Time.Format()`. Only one specific ISO 8601 format is
-supported by the `String()` or `BuildString()` functions.
+- `acetimgo` does not support access to a monotonic clock of the underlying
+  system. The sole purpose of acetimego is to support timezones and date-times
+  in the Gregorian calendar system.
+- `acetimego` does not support the `time.Duration` object. The difference
+  between two `acetime.Time` values can be represented as an `int64`.
+- `acetimego` does not support date arithmetics such as adding days or months.
+- `acetimego` does not support generalized formatting of the `ZonedDateTime`
+  object similar to `time.Time.Format()`. Only one specific ISO 8601 format is
+  supported by the `String()` or `BuildString()` functions.
+- The internal algorithms have been tested primarily from the year 0001 to 9999.
+  There may be bugs outside of that range.
 
 ## License
 

--- a/acetime/time_zone.go
+++ b/acetime/time_zone.go
@@ -108,14 +108,14 @@ func (tz *TimeZone) findZonedExtraForUnixSeconds(
 
 	// UTC or Error
 	if tz.processor == nil {
-		var resolvedFold FoldType
+		var resolved ResolvedType
 		if unixSeconds == InvalidUnixSeconds {
-			resolvedFold = FoldTypeNotFound
+			resolved = ResolvedError
 		} else {
-			resolvedFold = FoldTypeExact
+			resolved = ResolvedUnique
 		}
 		return ZonedExtra{
-			ResolvedFold:        resolvedFold,
+			Resolved:            resolved,
 			StdOffsetSeconds:    0,
 			DstOffsetSeconds:    0,
 			ReqStdOffsetSeconds: 0,
@@ -135,7 +135,7 @@ func (tz *TimeZone) findZonedExtraForUnixSeconds(
 	}
 
 	return ZonedExtra{
-		ResolvedFold:        FoldType(result.frtype),
+		Resolved:            ResolvedUnique,
 		StdOffsetSeconds:    result.stdOffsetSeconds,
 		DstOffsetSeconds:    result.dstOffsetSeconds,
 		ReqStdOffsetSeconds: result.reqStdOffsetSeconds,
@@ -215,14 +215,14 @@ func (tz *TimeZone) findZonedExtraForPlainDateTime(
 
 	// UTC or Error
 	if tz.processor == nil {
-		var resolvedFold FoldType
+		var resolved ResolvedType
 		if pdt.IsError() {
-			resolvedFold = FoldTypeNotFound
+			resolved = ResolvedError
 		} else {
-			resolvedFold = FoldTypeExact
+			resolved = ResolvedUnique
 		}
 		return ZonedExtra{
-			ResolvedFold:        resolvedFold,
+			Resolved:            resolved,
 			StdOffsetSeconds:    0,
 			DstOffsetSeconds:    0,
 			ReqStdOffsetSeconds: 0,
@@ -236,8 +236,9 @@ func (tz *TimeZone) findZonedExtraForPlainDateTime(
 		return ZonedExtraError
 	}
 
+	resolved := resolveForResultTypeAndFold(result.frtype, result.foldNumber)
 	return ZonedExtra{
-		ResolvedFold:        FoldType(result.frtype),
+		Resolved:            resolved,
 		StdOffsetSeconds:    result.stdOffsetSeconds,
 		DstOffsetSeconds:    result.dstOffsetSeconds,
 		ReqStdOffsetSeconds: result.reqStdOffsetSeconds,

--- a/acetime/zone_processor.go
+++ b/acetime/zone_processor.go
@@ -25,6 +25,7 @@ const (
 	errGeneric
 )
 
+// Sizes of internal buffers
 const (
 	maxMatches       = 4
 	maxInteriorYears = 4
@@ -682,16 +683,17 @@ func createAbbreviation(
 //---------------------------------------------------------------------------
 
 // Values of the findResult.frtype field. Must be identical to FoldType enums.
+type findResultType uint8
+
 const (
-	findResultErr = iota
-	findResultNotFound
+	findResultNotFound findResultType = iota
 	findResultExact
 	findResultGap
 	findResultOverlap
 )
 
 var (
-	findResultError = findResult{frtype: findResultErr}
+	findResultError = findResult{frtype: findResultNotFound}
 )
 
 // This object contains the result of a search, either using findByUnixSeconds()
@@ -699,45 +701,46 @@ var (
 //
 // The `frtype` determines the high-level result of the query using the
 // epochSeconds or plainDateTime. It is one of the `findResult` enums:
-// findResultErr, findResultNotFound, findResultExact, findResultGap, or
-// findResultOverlap.
+// findResultNotFound, findResultExact, findResultGap, or findResultOverlap.
 //
-// The `fold` parameter identifies the transition rule that was used to resolve
-// the search: 0 means "earlier", and 1 means "later". The effect on the
+// The `foldNumber` parameter identifies the transition rule that was used to
+// resolve the search: 0 means "earlier", and 1 means "later". The effect on the
 // resulting ZonedDateTime or ZonedExtra object is slightly different depending
 // overlap versus gap.
 //
-// The `frtype` field is exposed as `ZonedExtra.FoldType`. The `fold` parameter
-// was previously exposed to the end-users, but is now used for internal
-// purposes only. It is combined with the `frtype` to to determine the
+// The `frtype` field is exposed as `ZonedExtra.FoldType`. The `foldNumber`
+// parameter was previously exposed to the end-users, but is now used for
+// internal purposes only. It is combined with the `frtype` to to determine the
 // `ZonedDateTime.resolved` parameter.
 //
-// For findByUnixSeconds(), the `fold` parameter is relevant only if
+// For findByUnixSeconds(), the `foldNumber` parameter is relevant only if
 // unixSeconds falls in an overlap (frtype==findResultOverlap):
-// - fold=0 means that the requested unixSeconds matched a backwards shadow of a
-// later transition (e.g. the first time 1:30am was seen before a fallback from
-// 2am to 1am),
-// - fold=1 means that the requested unixSeconds matched the forward shadow of
-// an earlier transition (e.g. the second time 1:30am was seen after a fallback
-// from 2am to 1am).
+// - foldNumber=0 means that the requested unixSeconds matched a backwards
+// shadow of a later transition (e.g. the first time 1:30am was seen before a
+// fallback from 2am to 1am),
+// - foldNumber=1 means that the requested unixSeconds matched the forward
+// shadow of an earlier transition (e.g. the second time 1:30am was seen after a
+// fallback from 2am to 1am).
 //
-// For findByPlainDateTime(), the `fold` parameter is relevant for both
+// For findByPlainDateTime(), the `foldNumber` parameter is relevant for both
 // findResultGap and findResultOverlap.
 // - If the requested PlainDateTime is in an overlap:
-//    - `fold=0` means that the SelectEarlier option was requested, and
-//    - `fold=1` means that the SelectLater option was requested.
+//   - `foldNumber=0` means that the SelectEarlier option was requested, and
+//   - `foldNumber=1` means that the SelectLater option was requested.
+//
 // - If the PlainDateTime is in a gap:
-//    - `fold=0` means the earlier transition was requested by SelectLater, and
-//    - `fold=1` means that the later transition was selected using
-//    SelectEarlier.
+//   - `foldNumber=0` means the earlier transition was requested by
+//     SelectLater, and
+//   - `foldNumber=1` means that the later transition was selected using
+//     SelectEarlier.
 type findResult struct {
-	frtype              uint8  // findResult type
-	fold                uint8  // earlier (0) or later (1) transition
-	stdOffsetSeconds    int32  // STD offset
-	dstOffsetSeconds    int32  // DST offset
-	reqStdOffsetSeconds int32  // request STD offset
-	reqDstOffsetSeconds int32  // request DST offset
-	abbrev              string // abbreviation (e.g. PST, PDT)
+	frtype              findResultType // findResult type
+	foldNumber          uint8          // earlier (0) or later (1) transition
+	stdOffsetSeconds    int32          // STD offset
+	dstOffsetSeconds    int32          // DST offset
+	reqStdOffsetSeconds int32          // request STD offset
+	reqDstOffsetSeconds int32          // request DST offset
+	abbrev              string         // abbreviation (e.g. PST, PDT)
 }
 
 // Find the findResult at the given epoch_seconds.
@@ -757,7 +760,7 @@ func (zp *zoneProcessor) findByUnixSeconds(unixSeconds Time) findResult {
 		return findResultError
 	}
 
-	var frtype uint8
+	var frtype findResultType
 	if tfs.num == 2 {
 		frtype = findResultOverlap
 	} else {
@@ -765,7 +768,7 @@ func (zp *zoneProcessor) findByUnixSeconds(unixSeconds Time) findResult {
 	}
 	return findResult{
 		frtype:              frtype,
-		fold:                tfs.fold,
+		foldNumber:          tfs.fold,
 		stdOffsetSeconds:    transition.offsetSeconds,
 		dstOffsetSeconds:    transition.deltaSeconds,
 		reqStdOffsetSeconds: transition.offsetSeconds,
@@ -804,14 +807,14 @@ func (zp *zoneProcessor) findByPlainDateTime(
 
 	tfd := zp.tstorage.findTransitionForDateTime(pdt)
 
-	// Extract the appropriate transition, depending on the requested 'fold'
+	// Extract the appropriate transition, depending on the requested 'foldNumber'
 	// and the 'tfd.searchStatus'.
 	var transition *transition
 	var result findResult
 	if tfd.num == 1 {
 		transition = tfd.curr
 		result.frtype = findResultExact
-		result.fold = 0
+		result.foldNumber = 0
 		result.reqStdOffsetSeconds = transition.offsetSeconds
 		result.reqDstOffsetSeconds = transition.deltaSeconds
 	} else { // num = 0 or 2
@@ -819,7 +822,7 @@ func (zp *zoneProcessor) findByPlainDateTime(
 			// pdt was far past or far future, and didn't match anything.
 			transition = nil
 			result.frtype = findResultNotFound
-			result.fold = 0
+			result.foldNumber = 0
 		} else { // gap or overlap
 			if tfd.num == 0 { // gap
 				result.frtype = findResultGap
@@ -829,7 +832,7 @@ func (zp *zoneProcessor) findByPlainDateTime(
 					// and deltaSeconds from the earlier (prev) transition.
 					result.reqStdOffsetSeconds = tfd.prev.offsetSeconds
 					result.reqDstOffsetSeconds = tfd.prev.deltaSeconds
-					result.fold = 0
+					result.foldNumber = 0
 					// But after normalization, it will be shifted into the curr
 					// transition, so select 'curr' as the target transition.
 					transition = tfd.curr
@@ -838,7 +841,7 @@ func (zp *zoneProcessor) findByPlainDateTime(
 					// and deltaSeconds from the later (curr) transition.
 					result.reqStdOffsetSeconds = tfd.curr.offsetSeconds
 					result.reqDstOffsetSeconds = tfd.curr.deltaSeconds
-					result.fold = 1
+					result.foldNumber = 1
 					// But after normalization, it will be shifted into the prev
 					// transition, so select 'prev' as the target transition.
 					transition = tfd.prev
@@ -847,10 +850,10 @@ func (zp *zoneProcessor) findByPlainDateTime(
 				if disambiguate == DisambiguateCompatible ||
 					disambiguate == DisambiguateEarlier {
 					transition = tfd.prev
-					result.fold = 0
+					result.foldNumber = 0
 				} else {
 					transition = tfd.curr
-					result.fold = 1
+					result.foldNumber = 1
 				}
 				result.frtype = findResultOverlap
 				result.reqStdOffsetSeconds = transition.offsetSeconds

--- a/acetime/zone_processor.go
+++ b/acetime/zone_processor.go
@@ -682,7 +682,7 @@ func createAbbreviation(
 // findByPlainDateTime() and findByUnixSeconds()
 //---------------------------------------------------------------------------
 
-// Values of the findResult.frtype field. Must be identical to FoldType enums.
+// Values of the findResult.frtype field.
 type findResultType uint8
 
 const (
@@ -708,10 +708,8 @@ var (
 // resulting ZonedDateTime or ZonedExtra object is slightly different depending
 // overlap versus gap.
 //
-// The `frtype` field is exposed as `ZonedExtra.FoldType`. The `foldNumber`
-// parameter was previously exposed to the end-users, but is now used for
-// internal purposes only. It is combined with the `frtype` to to determine the
-// `ZonedDateTime.resolved` parameter.
+// The `frtype` and `foldNumber` are combined into `ZonedDateTime.Resolved` and
+// `ZonedExtra.Resolved`.
 //
 // For findByUnixSeconds(), the `foldNumber` parameter is relevant only if
 // unixSeconds falls in an overlap (frtype==findResultOverlap):

--- a/acetime/zoned_date_time.go
+++ b/acetime/zoned_date_time.go
@@ -13,8 +13,10 @@ var (
 
 // Resolved disambiguation of the ZonedDateTime from its UnixSeconds or
 // PlainDateTime.
+type ResolvedType uint8
+
 const (
-	ResolvedUnique = iota
+	ResolvedUnique ResolvedType = iota
 	ResolvedOverlapEarlier
 	ResolvedOverlapLater
 	ResolvedGapEarlier
@@ -35,7 +37,7 @@ const (
 type ZonedDateTime struct {
 	OffsetDateTime
 	Tz       *TimeZone
-	Resolved uint8
+	Resolved ResolvedType
 }
 
 // Converts from Unix unixSeconds.

--- a/acetime/zoned_date_time.go
+++ b/acetime/zoned_date_time.go
@@ -16,7 +16,8 @@ var (
 type ResolvedType uint8
 
 const (
-	ResolvedUnique ResolvedType = iota
+	ResolvedError ResolvedType = iota
+	ResolvedUnique
 	ResolvedOverlapEarlier
 	ResolvedOverlapLater
 	ResolvedGapEarlier
@@ -94,21 +95,6 @@ func (zdt *ZonedDateTime) Normalize(disambiguate uint8) {
 		&zdt.OffsetDateTime.PlainDateTime, disambiguate)
 	zdt.OffsetDateTime = odt
 	zdt.Resolved = resolved
-}
-
-// ZonedExtra returns the ZonedExtra object corresponding to the current
-// ZonedDateTime. This is will be always identical to the value returned by
-// ZonedExtraFromUnixSeconds().
-//
-// It will usually be identical to the value returned by
-// ZonedExtraFromPlainDateTime() except when the PlainDateTime falls in a gap
-// (FoldTypeGap). In that case, the ZonedDateTime has already been normalized
-// into a real ZonedDateTime, and ZonedExtraFromPlainDateTime() should be
-// called with the original PlainDateTime if the information about the
-// non-existent PlainDateTime is required.
-func (zdt *ZonedDateTime) ZonedExtra() ZonedExtra {
-	return zdt.Tz.findZonedExtraForUnixSeconds(
-		zdt.OffsetDateTime.UnixSeconds())
 }
 
 // String returns the given ZonedDateTime in ISO8601 format, in the form of

--- a/acetime/zoned_date_time_test.go
+++ b/acetime/zoned_date_time_test.go
@@ -7,6 +7,16 @@ import (
 )
 
 //-----------------------------------------------------------------------------
+// ZonedDateTimeError
+//-----------------------------------------------------------------------------
+
+func TestZonedDateTimeError(t *testing.T) {
+	if ZonedDateTimeError.Resolved != ResolvedError {
+		t.Fatal("ZonedDateTimeError.Resolved should be ResolvedError")
+	}
+}
+
+//-----------------------------------------------------------------------------
 // ZonedDateTime.
 // Much of the following tests adapted from zoned_date_time_test.c from the
 // acetimec library, which in turn, were adopted from
@@ -108,12 +118,6 @@ func TestZonedDateTimeFromUnixSeconds(t *testing.T) {
 	if !(unixSeconds == zdt.UnixSeconds()) {
 		t.Fatal(zdt)
 	}
-
-	expectedExtra := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra := zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
-	}
 }
 
 func TestZonedDateTimeFromUnixSeconds_2050(t *testing.T) {
@@ -137,12 +141,6 @@ func TestZonedDateTimeFromUnixSeconds_2050(t *testing.T) {
 	}
 	if !(unixSeconds == zdt.UnixSeconds()) {
 		t.Fatal(zdt.UnixSeconds())
-	}
-
-	expectedExtra := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra := zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
 	}
 }
 
@@ -168,11 +166,6 @@ func TestZonedDateTimeFromUnixSeconds_UnixMax(t *testing.T) {
 	if !(unixSeconds == zdt.UnixSeconds()) {
 		t.Fatal(zdt.UnixSeconds())
 	}
-	expectedExtra := ZonedExtra{FoldTypeExact, 0, 0, 0, 0, "UTC"}
-	extra := zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
-	}
 }
 
 func TestZonedDateTimeFromUnixSeconds_Invalid(t *testing.T) {
@@ -185,10 +178,6 @@ func TestZonedDateTimeFromUnixSeconds_Invalid(t *testing.T) {
 	}
 	if !(unixSeconds == zdt.UnixSeconds()) {
 		t.Fatal(zdt)
-	}
-	extra := zdt.ZonedExtra()
-	if !extra.IsError() {
-		t.Fatal(extra)
 	}
 }
 
@@ -217,13 +206,6 @@ func TestZonedDateTimeFromUnixSeconds_FallBack(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra := ZonedExtra{
-		FoldTypeOverlap, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
-	}
-	extra := zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
-	}
 
 	// Go forward an hour. Should return 01:29:00-08:00.
 	unixSeconds += 3600
@@ -242,13 +224,6 @@ func TestZonedDateTimeFromUnixSeconds_FallBack(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{
-		FoldTypeOverlap, -8 * 3600, 0, -8 * 3600, 0, "PST",
-	}
-	extra = zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
-	}
 
 	// Go forward another hour. Should return 02:29:00-08:00.
 	unixSeconds += 3600
@@ -266,11 +241,6 @@ func TestZonedDateTimeFromUnixSeconds_FallBack(t *testing.T) {
 	}
 	if !(zdt == expected) {
 		t.Fatal(zdt)
-	}
-	expectedExtra = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra = zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
 	}
 }
 
@@ -299,11 +269,6 @@ func TestZonedDateTimeFromUnixSeconds_SpringForward(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra := zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
-	}
 
 	// An hour later, we spring forward to 03:29:00-07:00.
 	unixSeconds += 3600
@@ -321,13 +286,6 @@ func TestZonedDateTimeFromUnixSeconds_SpringForward(t *testing.T) {
 	}
 	if !(zdt == expected) {
 		t.Fatal(zdt)
-	}
-	expectedExtra = ZonedExtra{
-		FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
-	}
-	extra = zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
 	}
 }
 
@@ -359,11 +317,6 @@ func TestZonedDateTimeFromPlainDateTime(t *testing.T) {
 	if !(unixSeconds == 946684800+8*60*60) {
 		t.Fatal(unixSeconds)
 	}
-	expectedExtra := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra := zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
-	}
 
 	// check that DisambiguateReversed gives identical results, there is only one
 	// match
@@ -386,11 +339,6 @@ func TestZonedDateTimeFromPlainDateTime(t *testing.T) {
 	unixSeconds = zdt.UnixSeconds()
 	if !(unixSeconds == 946684800+8*60*60) {
 		t.Fatal(unixSeconds)
-	}
-	expectedExtra = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra = zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
 	}
 }
 
@@ -418,11 +366,6 @@ func TestZonedDateTimeFromPlainDateTime_2050(t *testing.T) {
 	if !(unixSeconds == 2524608000+8*60*60) {
 		t.Fatal(unixSeconds)
 	}
-	expectedExtra := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra := zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
-	}
 
 	// check that DisambiguateReversed gives identical results, since there is one
 	// match
@@ -445,11 +388,6 @@ func TestZonedDateTimeFromPlainDateTime_2050(t *testing.T) {
 	unixSeconds = zdt.UnixSeconds()
 	if !(unixSeconds == 2524608000+8*60*60) {
 		t.Fatal(unixSeconds)
-	}
-	expectedExtra = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra = zdt.ZonedExtra()
-	if extra != expectedExtra {
-		t.Fatal(extra)
 	}
 }
 
@@ -474,8 +412,10 @@ func TestZonedDateTimeFromPlainDateTime_BeforeGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra := zdt.ZonedExtra()
+
+	// Check ZonedExtra
+	extra := ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
+	expectedExtra := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -498,8 +438,10 @@ func TestZonedDateTimeFromPlainDateTime_BeforeGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra = zdt.ZonedExtra()
+
+	// Check ZonedExtra
+	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateReversed)
+	expectedExtra = ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -528,10 +470,12 @@ func TestZonedDateTimeFromPlainDateTime_InGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra := ZonedExtra{FoldTypeGap, -8 * 3600, 3600, -8 * 3600, 0, "PDT"}
-	// Instead of calling 'zdt.ZonedExtra()', use the original PlainDateTime,
-	// because the zdt has already been resolved to a real date time.
+
+	// Check ZonedExtra
 	extra := ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
+	expectedExtra := ZonedExtra{
+		ResolvedGapLater, -8 * 3600, 3600, -8 * 3600, 0, "PDT",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -552,10 +496,12 @@ func TestZonedDateTimeFromPlainDateTime_InGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{FoldTypeGap, -8 * 3600, 3600, -8 * 3600, 0, "PDT"}
-	// Instead of calling 'zdt.ZonedExtra()', use the original PlainDateTime,
-	// because the zdt has already been resolved to a real date time.
+
+	// Check ZonedExtra
 	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
+	expectedExtra = ZonedExtra{
+		ResolvedGapLater, -8 * 3600, 3600, -8 * 3600, 0, "PDT",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -576,10 +522,12 @@ func TestZonedDateTimeFromPlainDateTime_InGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{FoldTypeGap, -8 * 3600, 0, -8 * 3600, 3600, "PST"}
-	// Instead of calling 'zdt.ZonedExtra()', use the original PlainDateTime,
-	// because the zdt has already been resolved to a real date time.
+
+	// Check ZonedExtra
 	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateReversed)
+	expectedExtra = ZonedExtra{
+		ResolvedGapEarlier, -8 * 3600, 0, -8 * 3600, 3600, "PST",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -600,10 +548,12 @@ func TestZonedDateTimeFromPlainDateTime_InGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{FoldTypeGap, -8 * 3600, 0, -8 * 3600, 3600, "PST"}
-	// Instead of calling 'zdt.ZonedExtra()', use the original PlainDateTime,
-	// because the zdt has already been resolved to a real date time.
+
+	// Check ZonedExtra
 	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateReversed)
+	expectedExtra = ZonedExtra{
+		ResolvedGapEarlier, -8 * 3600, 0, -8 * 3600, 3600, "PST",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -630,10 +580,12 @@ func TestZonedDateTimeFromPlainDateTime_AfterGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
+
+	// Check ZonedExtra
+	extra := ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
 	expectedExtra := ZonedExtra{
-		FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
-	extra := zdt.ZonedExtra()
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -655,10 +607,12 @@ func TestZonedDateTimeFromPlainDateTime_AfterGap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
+
+	// Check ZonedExtra
+	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateReversed)
 	expectedExtra = ZonedExtra{
-		FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
-	extra = zdt.ZonedExtra()
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -686,10 +640,12 @@ func TestZonedDateTimeFromPlainDateTime_BeforeOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
+
+	// Check ZonedExtra
+	extra := ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
 	expectedExtra := ZonedExtra{
-		FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
-	extra := zdt.ZonedExtra()
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -711,10 +667,12 @@ func TestZonedDateTimeFromPlainDateTime_BeforeOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
+
+	// Check ZonedExtra
+	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateReversed)
 	expectedExtra = ZonedExtra{
-		FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
-	extra = zdt.ZonedExtra()
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -743,10 +701,12 @@ func TestZonedDateTimeFromPlainDateTime_InOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
+
+	// Check ZonedExtra
+	extra := ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
 	expectedExtra := ZonedExtra{
-		FoldTypeOverlap, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedOverlapEarlier, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
-	extra := zdt.ZonedExtra()
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -767,10 +727,12 @@ func TestZonedDateTimeFromPlainDateTime_InOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
+
+	// Check ZonedExtra
+	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateEarlier)
 	expectedExtra = ZonedExtra{
-		FoldTypeOverlap, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedOverlapEarlier, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
-	extra = zdt.ZonedExtra()
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -791,8 +753,12 @@ func TestZonedDateTimeFromPlainDateTime_InOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{FoldTypeOverlap, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra = zdt.ZonedExtra()
+
+	// Check ZonedExtra
+	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateLater)
+	expectedExtra = ZonedExtra{
+		ResolvedOverlapLater, -8 * 3600, 0, -8 * 3600, 0, "PST",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -813,8 +779,12 @@ func TestZonedDateTimeFromPlainDateTime_InOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{FoldTypeOverlap, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra = zdt.ZonedExtra()
+
+	// Check ZonedExtra
+	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateReversed)
+	expectedExtra = ZonedExtra{
+		ResolvedOverlapLater, -8 * 3600, 0, -8 * 3600, 0, "PST",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -841,8 +811,12 @@ func TestZonedDateTimeFromPlainDateTime_AfterOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra := zdt.ZonedExtra()
+
+	// Check ZonedExtra
+	extra := ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
+	expectedExtra := ZonedExtra{
+		ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -864,8 +838,12 @@ func TestZonedDateTimeFromPlainDateTime_AfterOverlap(t *testing.T) {
 	if !(zdt == expected) {
 		t.Fatal(zdt)
 	}
-	expectedExtra = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
-	extra = zdt.ZonedExtra()
+
+	// Check ZonedExtra
+	extra = ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateReversed)
+	expectedExtra = ZonedExtra{
+		ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST",
+	}
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -902,10 +880,12 @@ func TestZonedDateTimeConvertToTimeZone(t *testing.T) {
 	if !(nydt == expected) {
 		t.Fatal(nydt)
 	}
+
+	// Check ZonedExtra
+	extra := ZonedExtraFromPlainDateTime(&pdt, &tzNewYork, DisambiguateCompatible)
 	expectedExtra := ZonedExtra{
-		FoldTypeExact, -5 * 3600, 3600, -5 * 3600, 3600, "EDT",
+		ResolvedUnique, -5 * 3600, 3600, -5 * 3600, 3600, "EDT",
 	}
-	extra := nydt.ZonedExtra()
 	if extra != expectedExtra {
 		t.Fatal(extra)
 	}
@@ -924,15 +904,15 @@ func TestZonedDateTimeToZonedExtra(t *testing.T) {
 		t.Fatal(zdt)
 	}
 
+	extra := ZonedExtraFromPlainDateTime(&pdt, &tz, DisambiguateCompatible)
 	expected := ZonedExtra{
-		ResolvedFold:        FoldTypeExact,
+		Resolved:            ResolvedUnique,
 		StdOffsetSeconds:    -8 * 3600,
 		DstOffsetSeconds:    1 * 3600,
 		ReqStdOffsetSeconds: -8 * 3600,
 		ReqDstOffsetSeconds: 1 * 3600,
 		Abbrev:              "PDT",
 	}
-	extra := zdt.ZonedExtra()
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}

--- a/acetime/zoned_date_time_test.go
+++ b/acetime/zoned_date_time_test.go
@@ -925,7 +925,7 @@ func TestZonedDateTimeToZonedExtra(t *testing.T) {
 	}
 
 	expected := ZonedExtra{
-		FoldType:            FoldTypeExact,
+		ResolvedFold:        FoldTypeExact,
 		StdOffsetSeconds:    -8 * 3600,
 		DstOffsetSeconds:    1 * 3600,
 		ReqStdOffsetSeconds: -8 * 3600,

--- a/acetime/zoned_extra.go
+++ b/acetime/zoned_extra.go
@@ -1,16 +1,17 @@
 package acetime
 
-// FoldType. Must be identical to findResult enums.
+// FoldKind, the type of the FoldType. Must be identical to findResult enums.
+type FoldType uint8
+
 const (
-	FoldTypeErr = iota
-	FoldTypeNotFound
+	FoldTypeNotFound FoldType = iota
 	FoldTypeExact
 	FoldTypeGap
 	FoldTypeOverlap
 )
 
 var (
-	ZonedExtraError = ZonedExtra{FoldType: FoldTypeErr}
+	ZonedExtraError = ZonedExtra{ResolvedFold: FoldTypeNotFound}
 )
 
 // ZonedExtra contains information about a specific instant in time (either at a
@@ -18,12 +19,12 @@ var (
 // captured by the OffsetDateTime. These include the STD offset, the DST offset,
 // and the abbreviation.
 type ZonedExtra struct {
-	FoldType            uint8  // type of fold (e.g. gap, overlap)
-	StdOffsetSeconds    int32  // STD offset
-	DstOffsetSeconds    int32  // DST offset
-	ReqStdOffsetSeconds int32  // request STD offset
-	ReqDstOffsetSeconds int32  // request DST offset
-	Abbrev              string // abbreviation (e.g. PST, PDT)
+	ResolvedFold        FoldType // type of fold (e.g. gap, overlap)
+	StdOffsetSeconds    int32    // STD offset
+	DstOffsetSeconds    int32    // DST offset
+	ReqStdOffsetSeconds int32    // request STD offset
+	ReqDstOffsetSeconds int32    // request DST offset
+	Abbrev              string   // abbreviation (e.g. PST, PDT)
 }
 
 func ZonedExtraFromUnixSeconds(
@@ -39,7 +40,7 @@ func ZonedExtraFromPlainDateTime(
 }
 
 func (extra *ZonedExtra) IsError() bool {
-	return extra.FoldType == FoldTypeErr
+	return extra.ResolvedFold == FoldTypeNotFound
 }
 
 // OffsetSeconds returns the total offset from UTC in seconds (StdOffsetSeconds

--- a/acetime/zoned_extra.go
+++ b/acetime/zoned_extra.go
@@ -1,17 +1,7 @@
 package acetime
 
-// FoldKind, the type of the FoldType. Must be identical to findResult enums.
-type FoldType uint8
-
-const (
-	FoldTypeNotFound FoldType = iota
-	FoldTypeExact
-	FoldTypeGap
-	FoldTypeOverlap
-)
-
 var (
-	ZonedExtraError = ZonedExtra{ResolvedFold: FoldTypeNotFound}
+	ZonedExtraError = ZonedExtra{Resolved: ResolvedError}
 )
 
 // ZonedExtra contains information about a specific instant in time (either at a
@@ -19,12 +9,12 @@ var (
 // captured by the OffsetDateTime. These include the STD offset, the DST offset,
 // and the abbreviation.
 type ZonedExtra struct {
-	ResolvedFold        FoldType // type of fold (e.g. gap, overlap)
-	StdOffsetSeconds    int32    // STD offset
-	DstOffsetSeconds    int32    // DST offset
-	ReqStdOffsetSeconds int32    // request STD offset
-	ReqDstOffsetSeconds int32    // request DST offset
-	Abbrev              string   // abbreviation (e.g. PST, PDT)
+	Resolved            ResolvedType
+	StdOffsetSeconds    int32  // STD offset
+	DstOffsetSeconds    int32  // DST offset
+	ReqStdOffsetSeconds int32  // request STD offset
+	ReqDstOffsetSeconds int32  // request DST offset
+	Abbrev              string // abbreviation (e.g. PST, PDT)
 }
 
 func ZonedExtraFromUnixSeconds(
@@ -40,7 +30,7 @@ func ZonedExtraFromPlainDateTime(
 }
 
 func (extra *ZonedExtra) IsError() bool {
-	return extra.ResolvedFold == FoldTypeNotFound
+	return extra.Resolved == ResolvedError
 }
 
 // OffsetSeconds returns the total offset from UTC in seconds (StdOffsetSeconds

--- a/acetime/zoned_extra_test.go
+++ b/acetime/zoned_extra_test.go
@@ -9,24 +9,8 @@ import (
 // ZonedExtra.
 //-----------------------------------------------------------------------------
 
-// Test that FoldTypeXxx constants are the same as findResultXxx constants.
-func TestFoldTypeTypeConstantsMatch(t *testing.T) {
-	if !(FoldTypeNotFound == FoldType(findResultNotFound)) {
-		t.Fatal("FoldTypeNotFound")
-	}
-	if !(FoldTypeExact == FoldType(findResultExact)) {
-		t.Fatal("FoldTypeExact")
-	}
-	if !(FoldTypeGap == FoldType(findResultGap)) {
-		t.Fatal("FoldTypeGap")
-	}
-	if !(FoldTypeOverlap == FoldType(findResultOverlap)) {
-		t.Fatal("FoldTypeOverlap")
-	}
-}
-
 func TestOffsetSeconds(t *testing.T) {
-	extra := ZonedExtra{FoldTypeExact, 1, 2, 3, 4, "ABC"}
+	extra := ZonedExtra{ResolvedUnique, 1, 2, 3, 4, "ABC"}
 	if extra.OffsetSeconds() != 1+2 {
 		t.Fatal(extra)
 	}
@@ -45,7 +29,7 @@ func TestZonedExtraFromUnixSeconds(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -59,7 +43,7 @@ func TestZonedExtraFromUnixSeconds_2050(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -73,7 +57,7 @@ func TestZonedExtraFromUnixSeconds_UnixMax(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, 0, 0, 0, 0, "UTC"}
+	expected := ZonedExtra{ResolvedUnique, 0, 0, 0, 0, "UTC"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -104,20 +88,20 @@ func TestZonedExtraFromUnixSeconds_FallBack(t *testing.T) {
 		t.Fatal(extra)
 	}
 	expected := ZonedExtra{
-		FoldTypeOverlap, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
 
 	// Go forward an hour. Should return 01:29:00-08:00, the second time this
-	// was seen, so fold should be 1.
+	// was seen.
 	unixSeconds += 3600
 	extra = ZonedExtraFromUnixSeconds(unixSeconds, &tz)
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeOverlap, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -129,7 +113,7 @@ func TestZonedExtraFromUnixSeconds_FallBack(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -149,7 +133,7 @@ func TestZonedExtraFromUnixSeconds_SpringForward(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -160,7 +144,7 @@ func TestZonedExtraFromUnixSeconds_SpringForward(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -179,7 +163,7 @@ func TestZonedExtraFromPlainDateTime(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -191,7 +175,7 @@ func TestZonedExtraFromPlainDateTime(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -206,7 +190,7 @@ func TestZonedExtraFromPlainDateTime_2050(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -218,7 +202,7 @@ func TestZonedExtraFromPlainDateTime_2050(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -234,7 +218,7 @@ func TestZonedExtraFromPlainDateTime_BeforeGap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -246,7 +230,7 @@ func TestZonedExtraFromPlainDateTime_BeforeGap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -263,7 +247,7 @@ func TestZonedExtraFromPlainDateTime_InGap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeGap, -8 * 3600, 3600, -8 * 3600, 0, "PDT"}
+	expected := ZonedExtra{ResolvedGapLater, -8 * 3600, 3600, -8 * 3600, 0, "PDT"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -275,7 +259,9 @@ func TestZonedExtraFromPlainDateTime_InGap(t *testing.T) {
 		t.Fatal(extra)
 	}
 	// fold == 0 to indicate the 1st transition
-	expected = ZonedExtra{FoldTypeGap, -8 * 3600, 0, -8 * 3600, 3600, "PST"}
+	expected = ZonedExtra{
+		ResolvedGapEarlier, -8 * 3600, 0, -8 * 3600, 3600, "PST",
+	}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -292,7 +278,7 @@ func TestZonedExtraFromPlainDateTime_AfterGap(t *testing.T) {
 		t.Fatal(extra)
 	}
 	expected := ZonedExtra{
-		FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
 	if !(extra == expected) {
 		t.Fatal(extra)
@@ -304,7 +290,7 @@ func TestZonedExtraFromPlainDateTime_AfterGap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -321,7 +307,9 @@ func TestZonedExtraFromPlainDateTime_BeforeOverlap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT"}
+	expected := ZonedExtra{
+		ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+	}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -332,7 +320,7 @@ func TestZonedExtraFromPlainDateTime_BeforeOverlap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 3600, -8 * 3600, 3600, "PDT"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 3600, -8 * 3600, 3600, "PDT"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -350,7 +338,7 @@ func TestZonedExtraFromPlainDateTime_InOverlap(t *testing.T) {
 		t.Fatal(extra)
 	}
 	expected := ZonedExtra{
-		FoldTypeOverlap, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
+		ResolvedOverlapEarlier, -8 * 3600, 3600, -8 * 3600, 3600, "PDT",
 	}
 	if !(extra == expected) {
 		t.Fatal(extra)
@@ -361,7 +349,7 @@ func TestZonedExtraFromPlainDateTime_InOverlap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeOverlap, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected = ZonedExtra{ResolvedOverlapLater, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -377,7 +365,7 @@ func TestZonedExtraFromPlainDateTime_AfterOverlap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected := ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected := ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}
@@ -388,7 +376,7 @@ func TestZonedExtraFromPlainDateTime_AfterOverlap(t *testing.T) {
 	if extra.IsError() {
 		t.Fatal(extra)
 	}
-	expected = ZonedExtra{FoldTypeExact, -8 * 3600, 0, -8 * 3600, 0, "PST"}
+	expected = ZonedExtra{ResolvedUnique, -8 * 3600, 0, -8 * 3600, 0, "PST"}
 	if !(extra == expected) {
 		t.Fatal(extra)
 	}

--- a/acetime/zoned_extra_test.go
+++ b/acetime/zoned_extra_test.go
@@ -11,19 +11,16 @@ import (
 
 // Test that FoldTypeXxx constants are the same as findResultXxx constants.
 func TestFoldTypeTypeConstantsMatch(t *testing.T) {
-	if !(FoldTypeErr == findResultErr) {
-		t.Fatal("FoldTypeErr")
-	}
-	if !(FoldTypeNotFound == findResultNotFound) {
+	if !(FoldTypeNotFound == FoldType(findResultNotFound)) {
 		t.Fatal("FoldTypeNotFound")
 	}
-	if !(FoldTypeExact == findResultExact) {
+	if !(FoldTypeExact == FoldType(findResultExact)) {
 		t.Fatal("FoldTypeExact")
 	}
-	if !(FoldTypeGap == findResultGap) {
+	if !(FoldTypeGap == FoldType(findResultGap)) {
 		t.Fatal("FoldTypeGap")
 	}
-	if !(FoldTypeOverlap == findResultOverlap) {
+	if !(FoldTypeOverlap == FoldType(findResultOverlap)) {
 		t.Fatal("FoldTypeOverlap")
 	}
 }

--- a/cmd/mem_go_time/esp32.size.txt
+++ b/cmd/mem_go_time/esp32.size.txt
@@ -1,25 +1,26 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
       0       8       0       9 |       8       9 | (padding)
-   2518     867       0       4 |    3385       4 | (unknown)
+   2441     894       0       4 |    3335       4 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
-     89       0       0       0 |      89       0 | Go interface method
-      0     288       0       0 |     288       0 | Go types
+     12       0       0       0 |      12       0 | Go interface method
+      0     280       0       0 |     280       0 | Go types
      66       0       0       0 |      66       0 | device/esp
      22       0       0       0 |      22       0 | errors
-    209       0       0       0 |     209       0 | github.com/bxparks/acetimego/internal/strbuild
-    142       2       0       0 |     144       0 | internal/itoa
-    351      24       0       8 |     375       8 | internal/task
-     20       0       0       0 |      20       0 | machine
-    200     156       0       0 |     356       0 | main
-   3850     591       0       0 |    4441       0 | reflect
-   3149     213       0      47 |    3362      47 | runtime
-     79       0       0       0 |      79       0 | runtime/interrupt
-    101       0       0       0 |     101       0 | runtime/volatile
-    127      64       0       0 |     191       0 | strings
-    144      38       0       0 |     182       0 | sync
+    207       0       0       0 |     207       0 | github.com/bxparks/acetimego/internal/strbuild
+    161       2       0       0 |     163       0 | internal/itoa
+   4094     590      48       0 |    4732      48 | internal/reflectlite
+    401      62       0       8 |     463       8 | internal/task
+      9       0       0       0 |       9       0 | machine
+    212     156       0       0 |     368       0 | main
+     19       0       0       0 |      19       0 | math/bits
+   3321     213       0      63 |    3534      63 | runtime
+     76       0       0       0 |      76       0 | runtime/interrupt
+    107       0       0       0 |     107       0 | runtime/volatile
+    121      64       0       0 |     185       0 | strings
+     84       0       0       0 |      84       0 | sync
      32       6       0       0 |      38       0 | syscall
-   8613     727      96      88 |    9436     184 | time
-    384     288       0       0 |     672       0 | unicode/utf8
+   7779     689     104      88 |    8572     192 | time
+    368     288       0       0 |     656       0 | unicode/utf8
 ------------------------------- | --------------- | -------
-  20096    3272      96    4252 |   23464    4348 | total
+  19532    3252     152    4268 |   22936    4420 | total

--- a/cmd/mem_go_time/tiny.size.txt
+++ b/cmd/mem_go_time/tiny.size.txt
@@ -1,25 +1,28 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0      28       4      14 |      32      18 | (padding)
-     27   11079      12      78 |   11118      90 | (unknown)
-   1598    3576       0      72 |    5174      72 | /usr/local/go/src/syscall
-   3850      58      12     536 |    3920     548 | C musl
-    284       0       0       0 |     284       0 | Go interface assert
-     29       0       0       0 |      29       0 | Go interface method
-      0     696       0       0 |     696       0 | Go types
+      0      16       4      14 |      20      18 | (padding)
+     27   21077      20     978 |   21124     998 | (unknown)
+   1458    3801       0      28 |    5259      28 | /usr/local/go/src/syscall
+  26972    3617     872  118018 |   31461  118890 | C bdwgc
+  16680    3025      12     576 |   19717     588 | C musl
+    126       0       0       0 |     126       0 | Go interface assert
+     96       0       0       0 |      96       0 | Go interface method
+      0     472       0       0 |     472       0 | Go types
      43       0       0       0 |      43       0 | errors
     161       0       0       0 |     161       0 | github.com/bxparks/acetimego/internal/strbuild
-     26       0       0       0 |      26       0 | internal/bytealg
-    155       2       0       0 |     157       0 | internal/itoa
-    479      24       0      16 |     503      16 | internal/task
-    270     156       0       0 |     426       0 | main
-   4819     622       0       0 |    5441       0 | reflect
-   6710     243      12      91 |    6965     103 | runtime
-    138      72       0       0 |     210       0 | strings
-    638     200       0       0 |     838       0 | sync
-     90      75       0       1 |     165       1 | sync/atomic
-    193    1506       0       0 |    1699       0 | syscall
-  18606    1003     168     152 |   19777     320 | time
-    319     288       0       0 |     607       0 | unicode/utf8
+     94       0       0       0 |      94       0 | internal/bytealg
+    167       0       0       0 |     167       0 | internal/futex
+    160       2       0       0 |     162       0 | internal/itoa
+   4912     623      96       0 |    5631      96 | internal/reflectlite
+    561      50       8      96 |     619     104 | internal/task
+    506     156       0       0 |     662       0 | main
+     27       0       0       0 |      27       0 | math/bits
+   5592     324       4     122 |    5920     126 | runtime
+    140      72       0       0 |     212       0 | strings
+    795      33       0       0 |     828       0 | sync
+    100       0       0       0 |     100       0 | sync/atomic
+    222    1277      40      25 |    1539      65 | syscall
+  18352     963     184     120 |   19499     304 | time
+    377     288       0       0 |     665       0 | unicode/utf8
 ------------------------------- | --------------- | -------
-  38435   19628     208     960 |   58271    1168 | total
+  77568   35796    1240  119977 |  114604  121217 | total

--- a/cmd/mem_zonedb2000/esp32.size.txt
+++ b/cmd/mem_zonedb2000/esp32.size.txt
@@ -1,20 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
       0       0       2       5 |       2       7 | (padding)
-   1262       4       2       0 |    1268       2 | (unknown)
+   1207      16       0       0 |    1223       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
      66       0       0       0 |      66       0 | device/esp
-   5929      31       0       0 |    5960       0 | github.com/bxparks/acetimego/acetime
-    436       0       0       0 |     436       0 | github.com/bxparks/acetimego/internal/strbuild
-      0   33974    1436       0 |   35410    1436 | github.com/bxparks/acetimego/zonedb
-   1996       0       0       0 |    1996       0 | github.com/bxparks/acetimego/zoneinfo
-     54       0       0       0 |      54       0 | internal/bytealg
-    302      24       0       8 |     326       8 | internal/task
-     20       0       0       0 |      20       0 | machine
-    252     158       0       0 |     410       0 | main
-   2191     172       0      47 |    2363      47 | runtime
-     56       0       0       0 |      56       0 | runtime/interrupt
-    101       0       0       0 |     101       0 | runtime/volatile
-    435     108       0       0 |     543       0 | strings
+   5717      31       0       0 |    5748       0 | github.com/bxparks/acetimego/acetime
+    411       0       0       0 |     411       0 | github.com/bxparks/acetimego/internal/strbuild
+      0   34031    1438       0 |   35469    1438 | github.com/bxparks/acetimego/zonedb2000
+   1934       0       0       0 |    1934       0 | github.com/bxparks/acetimego/zoneinfo
+     59       0       0       0 |      59       0 | internal/bytealg
+     37       0       0       0 |      37       0 | internal/stringslite
+    292      24       0       8 |     316       8 | internal/task
+      9       0       0       0 |       9       0 | machine
+    264     158       0       0 |     422       0 | main
+     10       0       0       0 |      10       0 | math/bits
+   2301     172       0      63 |    2473      63 | runtime
+     53       0       0       0 |      53       0 | runtime/interrupt
+    107       0       0       0 |     107       0 | runtime/volatile
+    465     108       0       0 |     573       0 | strings
 ------------------------------- | --------------- | -------
-  13100   34471    1440    4156 |   49011    5596 | total
+  12932   34540    1440    4172 |   48912    5612 | total

--- a/cmd/mem_zonedb2000/tiny.size.txt
+++ b/cmd/mem_zonedb2000/tiny.size.txt
@@ -1,17 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0       5       6      14 |      11      20 | (padding)
-     27    4458      20      24 |    4505      44 | (unknown)
-   3002      27       4     536 |    3033     540 | C musl
+      0       0       6      10 |       6      16 | (padding)
+     27   15059      20     966 |   15106     986 | (unknown)
+  26972    3610     872  118018 |   31454  118890 | C bdwgc
+  16680    3025      12     576 |   19717     588 | C musl
       0      32       0       0 |      32       0 | Go types
-   6729      63       0       0 |    6792       0 | github.com/bxparks/acetimego/acetime
-    470       0       0       0 |     470       0 | github.com/bxparks/acetimego/internal/strbuild
+   6559      63       0       0 |    6622       0 | github.com/bxparks/acetimego/acetime
+    450       0       0       0 |     450       0 | github.com/bxparks/acetimego/internal/strbuild
       0   34031    1546       0 |   35577    1546 | github.com/bxparks/acetimego/zonedb2000
-   2446       0       0       0 |    2446       0 | github.com/bxparks/acetimego/zoneinfo
-     59       0       0       0 |      59       0 | internal/bytealg
-    365      24       0      16 |     389      16 | internal/task
-    316     158       0       0 |     474       0 | main
-   3401     172       8      91 |    3581      99 | runtime
-    575     124       0       0 |     699       0 | strings
+   2404       0       0       0 |    2404       0 | github.com/bxparks/acetimego/zoneinfo
+     73       0       0       0 |      73       0 | internal/bytealg
+    153       0       0       0 |     153       0 | internal/futex
+     31       0       0       0 |      31       0 | internal/stringslite
+    529      50       8      96 |     587     104 | internal/task
+    496     158       0       0 |     654       0 | main
+      8       0       0       0 |       8       0 | math/bits
+   1953     253       0     122 |    2206     122 | runtime
+    544     124       0       0 |     668       0 | strings
+     42       0       0       0 |      42       0 | sync/atomic
 ------------------------------- | --------------- | -------
-  17390   39094    1584     681 |   58068    2265 | total
+  56921   56405    2464  119788 |  115790  122252 | total

--- a/cmd/mem_zonedb2025/esp32.size.txt
+++ b/cmd/mem_zonedb2025/esp32.size.txt
@@ -1,20 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
       0       0       2       5 |       2       7 | (padding)
-   1262       4       2       0 |    1268       2 | (unknown)
+   1207      16       0       0 |    1223       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
      66       0       0       0 |      66       0 | device/esp
-   5929      31       0       0 |    5960       0 | github.com/bxparks/acetimego/acetime
-    436       0       0       0 |     436       0 | github.com/bxparks/acetimego/internal/strbuild
-      0   33974    1436       0 |   35410    1436 | github.com/bxparks/acetimego/zonedb
-   1996       0       0       0 |    1996       0 | github.com/bxparks/acetimego/zoneinfo
-     54       0       0       0 |      54       0 | internal/bytealg
-    302      24       0       8 |     326       8 | internal/task
-     20       0       0       0 |      20       0 | machine
-    252     158       0       0 |     410       0 | main
-   2191     172       0      47 |    2363      47 | runtime
-     56       0       0       0 |      56       0 | runtime/interrupt
-    101       0       0       0 |     101       0 | runtime/volatile
-    435     108       0       0 |     543       0 | strings
+   5717      31       0       0 |    5748       0 | github.com/bxparks/acetimego/acetime
+    411       0       0       0 |     411       0 | github.com/bxparks/acetimego/internal/strbuild
+      0   25050    1422       0 |   26472    1422 | github.com/bxparks/acetimego/zonedb2025
+   1934       0       0       0 |    1934       0 | github.com/bxparks/acetimego/zoneinfo
+     59       0       0       0 |      59       0 | internal/bytealg
+     37       0       0       0 |      37       0 | internal/stringslite
+    292      24       0       8 |     316       8 | internal/task
+      9       0       0       0 |       9       0 | machine
+    264     158       0       0 |     422       0 | main
+     10       0       0       0 |      10       0 | math/bits
+   2301     172       0      63 |    2473      63 | runtime
+     53       0       0       0 |      53       0 | runtime/interrupt
+    107       0       0       0 |     107       0 | runtime/volatile
+    465     108       0       0 |     573       0 | strings
 ------------------------------- | --------------- | -------
-  13100   34471    1440    4156 |   49011    5596 | total
+  12932   25559    1424    4172 |   39915    5596 | total

--- a/cmd/mem_zonedb2025/tiny.size.txt
+++ b/cmd/mem_zonedb2025/tiny.size.txt
@@ -1,17 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0       2       0      14 |       2      14 | (padding)
-     27    4458      18      24 |    4503      42 | (unknown)
-   3002      27       4     536 |    3033     540 | C musl
+      0       0       6      10 |       6      16 | (padding)
+     27   15059      20    1758 |   15106    1778 | (unknown)
+  26972    3610     872  118018 |   31454  118890 | C bdwgc
+  16680    3025      12     576 |   19717     588 | C musl
       0      32       0       0 |      32       0 | Go types
-   6729      63       0       0 |    6792       0 | github.com/bxparks/acetimego/acetime
-    470       0       0       0 |     470       0 | github.com/bxparks/acetimego/internal/strbuild
+   6559      63       0       0 |    6622       0 | github.com/bxparks/acetimego/acetime
+    450       0       0       0 |     450       0 | github.com/bxparks/acetimego/internal/strbuild
       0   25050    1530       0 |   26580    1530 | github.com/bxparks/acetimego/zonedb2025
-   2446       0       0       0 |    2446       0 | github.com/bxparks/acetimego/zoneinfo
-     59       0       0       0 |      59       0 | internal/bytealg
-    365      24       0      16 |     389      16 | internal/task
-    316     158       0       0 |     474       0 | main
-   3401     172       8      91 |    3581      99 | runtime
-    575     124       0       0 |     699       0 | strings
+   2404       0       0       0 |    2404       0 | github.com/bxparks/acetimego/zoneinfo
+     73       0       0       0 |      73       0 | internal/bytealg
+    153       0       0       0 |     153       0 | internal/futex
+     31       0       0       0 |      31       0 | internal/stringslite
+    529      50       8      96 |     587     104 | internal/task
+    496     158       0       0 |     654       0 | main
+      8       0       0       0 |       8       0 | math/bits
+   1953     253       0     122 |    2206     122 | runtime
+    544     124       0       0 |     668       0 | strings
+     42       0       0       0 |      42       0 | sync/atomic
 ------------------------------- | --------------- | -------
-  17390   30110    1560     681 |   49060    2241 | total
+  56921   47424    2448  120580 |  106793  123028 | total

--- a/cmd/mem_zonedball/esp32.size.txt
+++ b/cmd/mem_zonedball/esp32.size.txt
@@ -1,20 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0       0       3       5 |       3       8 | (padding)
-   1262       4       4       0 |    1270       4 | (unknown)
+      0       0       1       5 |       1       6 | (padding)
+   1207      16       0       0 |    1223       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
      66       0       0       0 |      66       0 | device/esp
-   5929      31       0       0 |    5960       0 | github.com/bxparks/acetimego/acetime
-    436       0       0       0 |     436       0 | github.com/bxparks/acetimego/internal/strbuild
-      0   70645    1565       0 |   72210    1565 | github.com/bxparks/acetimego/zonedball
-   1996       0       0       0 |    1996       0 | github.com/bxparks/acetimego/zoneinfo
-     54       0       0       0 |      54       0 | internal/bytealg
-    302      24       0       8 |     326       8 | internal/task
-     20       0       0       0 |      20       0 | machine
-    252     161       0       0 |     413       0 | main
-   2191     172       0      47 |    2363      47 | runtime
-     56       0       0       0 |      56       0 | runtime/interrupt
-    101       0       0       0 |     101       0 | runtime/volatile
-    435     108       0       0 |     543       0 | strings
+   5717      31       0       0 |    5748       0 | github.com/bxparks/acetimego/acetime
+    411       0       0       0 |     411       0 | github.com/bxparks/acetimego/internal/strbuild
+      0   70870    1567       0 |   72437    1567 | github.com/bxparks/acetimego/zonedball
+   1934       0       0       0 |    1934       0 | github.com/bxparks/acetimego/zoneinfo
+     59       0       0       0 |      59       0 | internal/bytealg
+     37       0       0       0 |      37       0 | internal/stringslite
+    292      24       0       8 |     316       8 | internal/task
+      9       0       0       0 |       9       0 | machine
+    264     161       0       0 |     425       0 | main
+     10       0       0       0 |      10       0 | math/bits
+   2301     172       0      63 |    2473      63 | runtime
+     53       0       0       0 |      53       0 | runtime/interrupt
+    107       0       0       0 |     107       0 | runtime/volatile
+    465     108       0       0 |     573       0 | strings
 ------------------------------- | --------------- | -------
-  13100   71145    1572    4156 |   85817    5728 | total
+  12932   71382    1568    4172 |   85882    5740 | total

--- a/cmd/mem_zonedball/tiny.size.txt
+++ b/cmd/mem_zonedball/tiny.size.txt
@@ -1,17 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0       6       3      14 |       9      17 | (padding)
-     27    4458      22      24 |    4507      46 | (unknown)
-   3002      27       4     536 |    3033     540 | C musl
+      0       0       5      10 |       5      15 | (padding)
+     27   15059      20     990 |   15106    1010 | (unknown)
+  26972    3610     872  118018 |   31454  118890 | C bdwgc
+  16680    3025      12     576 |   19717     588 | C musl
       0      32       0       0 |      32       0 | Go types
-   6729      63       0       0 |    6792       0 | github.com/bxparks/acetimego/acetime
-    470       0       0       0 |     470       0 | github.com/bxparks/acetimego/internal/strbuild
+   6559      63       0       0 |    6622       0 | github.com/bxparks/acetimego/acetime
+    450       0       0       0 |     450       0 | github.com/bxparks/acetimego/internal/strbuild
       0   70870    1675       0 |   72545    1675 | github.com/bxparks/acetimego/zonedball
-   2446       0       0       0 |    2446       0 | github.com/bxparks/acetimego/zoneinfo
-     59       0       0       0 |      59       0 | internal/bytealg
-    365      24       0      16 |     389      16 | internal/task
-    316     161       0       0 |     477       0 | main
-   3401     172       8      91 |    3581      99 | runtime
-    575     124       0       0 |     699       0 | strings
+   2404       0       0       0 |    2404       0 | github.com/bxparks/acetimego/zoneinfo
+     73       0       0       0 |      73       0 | internal/bytealg
+    153       0       0       0 |     153       0 | internal/futex
+     31       0       0       0 |      31       0 | internal/stringslite
+    529      50       8      96 |     587     104 | internal/task
+    496     161       0       0 |     657       0 | main
+      8       0       0       0 |       8       0 | math/bits
+   1953     253       0     122 |    2206     122 | runtime
+    544     124       0       0 |     668       0 | strings
+     42       0       0       0 |      42       0 | sync/atomic
 ------------------------------- | --------------- | -------
-  17390   75937    1712     681 |   95039    2393 | total
+  56921   93247    2592  119812 |  152760  122404 | total

--- a/cmd/mem_zonedbtesting/esp32.size.txt
+++ b/cmd/mem_zonedbtesting/esp32.size.txt
@@ -1,20 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
       0       0       0       5 |       0       5 | (padding)
-   1262       4       0       0 |    1266       0 | (unknown)
+   1207      16       0       0 |    1223       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
      66       0       0       0 |      66       0 | device/esp
-   5929      31       0       0 |    5960       0 | github.com/bxparks/acetimego/acetime
-    436       0       0       0 |     436       0 | github.com/bxparks/acetimego/internal/strbuild
+   5717      31       0       0 |    5748       0 | github.com/bxparks/acetimego/acetime
+    411       0       0       0 |     411       0 | github.com/bxparks/acetimego/internal/strbuild
       0     383     152       0 |     535     152 | github.com/bxparks/acetimego/zonedbtesting
-   1996       0       0       0 |    1996       0 | github.com/bxparks/acetimego/zoneinfo
-     54       0       0       0 |      54       0 | internal/bytealg
-    302      24       0       8 |     326       8 | internal/task
-     20       0       0       0 |      20       0 | machine
-    252     165       0       0 |     417       0 | main
-   2191     172       0      47 |    2363      47 | runtime
-     56       0       0       0 |      56       0 | runtime/interrupt
-    101       0       0       0 |     101       0 | runtime/volatile
-    435     108       0       0 |     543       0 | strings
+   1934       0       0       0 |    1934       0 | github.com/bxparks/acetimego/zoneinfo
+     59       0       0       0 |      59       0 | internal/bytealg
+     37       0       0       0 |      37       0 | internal/stringslite
+    292      24       0       8 |     316       8 | internal/task
+      9       0       0       0 |       9       0 | machine
+    264     165       0       0 |     429       0 | main
+     10       0       0       0 |      10       0 | math/bits
+   2301     172       0      63 |    2473      63 | runtime
+     53       0       0       0 |      53       0 | runtime/interrupt
+    107       0       0       0 |     107       0 | runtime/volatile
+    465     108       0       0 |     573       0 | strings
 ------------------------------- | --------------- | -------
-  13100     887     152    4156 |   14139    4308 | total
+  12932     899     152    4172 |   13983    4324 | total

--- a/cmd/mem_zonedbtesting/tiny.size.txt
+++ b/cmd/mem_zonedbtesting/tiny.size.txt
@@ -1,17 +1,22 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0       5       4      14 |       9      18 | (padding)
-     27    4458      20      24 |    4505      44 | (unknown)
-   3002      27       4     536 |    3033     540 | C musl
+      0       0       4      10 |       4      14 | (padding)
+     27   15059      20    1838 |   15106    1858 | (unknown)
+  26972    3610     872  118018 |   31454  118890 | C bdwgc
+  16680    3025      12     576 |   19717     588 | C musl
       0      32       0       0 |      32       0 | Go types
-   6729      63       0       0 |    6792       0 | github.com/bxparks/acetimego/acetime
-    470       0       0       0 |     470       0 | github.com/bxparks/acetimego/internal/strbuild
+   6559      63       0       0 |    6622       0 | github.com/bxparks/acetimego/acetime
+    450       0       0       0 |     450       0 | github.com/bxparks/acetimego/internal/strbuild
       0     383     260       0 |     643     260 | github.com/bxparks/acetimego/zonedbtesting
-   2446       0       0       0 |    2446       0 | github.com/bxparks/acetimego/zoneinfo
-     59       0       0       0 |      59       0 | internal/bytealg
-    365      24       0      16 |     389      16 | internal/task
-    316     165       0       0 |     481       0 | main
-   3401     172       8      91 |    3581      99 | runtime
-    575     124       0       0 |     699       0 | strings
+   2404       0       0       0 |    2404       0 | github.com/bxparks/acetimego/zoneinfo
+     73       0       0       0 |      73       0 | internal/bytealg
+    153       0       0       0 |     153       0 | internal/futex
+     31       0       0       0 |      31       0 | internal/stringslite
+    529      50       8      96 |     587     104 | internal/task
+    496     165       0       0 |     661       0 | main
+      8       0       0       0 |       8       0 | math/bits
+   1953     253       0     122 |    2206     122 | runtime
+    544     124       0       0 |     668       0 | strings
+     42       0       0       0 |      42       0 | sync/atomic
 ------------------------------- | --------------- | -------
-  17390    5453     296     681 |   23139     977 | total
+  56921   22764    1176  120660 |   80861  121836 | total

--- a/examples/ds3231demo/esp32.size.txt
+++ b/examples/ds3231demo/esp32.size.txt
@@ -1,18 +1,18 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0       3       0       7 |       3       7 | (padding)
-   1035     181       0       0 |    1216       0 | (unknown)
+      0       2       0       6 |       2       6 | (padding)
+   1037     198       0       0 |    1235       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
       4       0       0       0 |       4       0 | Go interface method
-      0      92       0       0 |      92       0 | Go types
+      0      88       0       0 |      88       0 | Go types
      66       0       0       0 |      66       0 | device/esp
-    265       0       0       0 |     265       0 | github.com/bxparks/acetimego/ds3231
-    331      24       0       8 |     355       8 | internal/task
-    601       0       0       0 |     601       0 | machine
-    127       6       8       0 |     141       8 | main
-   2127     110       0      57 |    2237      57 | runtime
-     55       0       0       0 |      55       0 | runtime/interrupt
-    141       0       0       0 |     141       0 | runtime/volatile
-    986      32       8       0 |    1026       8 | tinygo.org/x/drivers/i2csoft
+    279       0       0       0 |     279       0 | github.com/bxparks/acetimego/ds3231
+    320      24       0       8 |     344       8 | internal/task
+    557       0       0       0 |     557       0 | machine
+    132       6       8       0 |     146       8 | main
+   2298     110       0      74 |    2408      74 | runtime
+     56       0       0       0 |      56       0 | runtime/interrupt
+    204       0       0       0 |     204       0 | runtime/volatile
+    910      32       8       0 |     950       8 | tinygo.org/x/drivers/i2csoft
 ------------------------------- | --------------- | -------
-   5738     448      16    4168 |    6202    4184 | total
+   5863     460      16    4184 |    6339    4200 | total

--- a/examples/helloacetime/esp32.size.txt
+++ b/examples/helloacetime/esp32.size.txt
@@ -1,21 +1,23 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
       0       0       2       5 |       2       7 | (padding)
-   1439       4       0       0 |    1443       0 | (unknown)
+   1383      16       0       0 |    1399       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
      66       0       0       0 |      66       0 | device/esp
-   6426      31       0       0 |    6457       0 | github.com/bxparks/acetimego/acetime
-    210       0       0       0 |     210       0 | github.com/bxparks/acetimego/internal/strbuild
+   6188      31       0       0 |    6219       0 | github.com/bxparks/acetimego/acetime
+    212       0       0       0 |     212       0 | github.com/bxparks/acetimego/internal/strbuild
       0   34031    1438       0 |   35469    1438 | github.com/bxparks/acetimego/zonedb2000
-   1856       0       0       0 |    1856       0 | github.com/bxparks/acetimego/zoneinfo
-     57       0       0       0 |      57       0 | internal/bytealg
-    316      24       0       8 |     340       8 | internal/task
-     20       0       0       0 |      20       0 | machine
-    332      77       0       0 |     409       0 | main
-   2587     172       0      59 |    2759      59 | runtime
-     55       0       0       0 |      55       0 | runtime/interrupt
-    117       0       0       0 |     117       0 | runtime/volatile
-    439     108       0       0 |     547       0 | strings
-    174       0       0       0 |     174       0 | time
+   1823       0       0       0 |    1823       0 | github.com/bxparks/acetimego/zoneinfo
+     59       0       0       0 |      59       0 | internal/bytealg
+     37       0       0       0 |      37       0 | internal/stringslite
+    310      24       0       8 |     334       8 | internal/task
+      9       0       0       0 |       9       0 | machine
+    313      77       0       0 |     390       0 | main
+     10       0       0       0 |      10       0 | math/bits
+   2678     172       0      75 |    2850      75 | runtime
+     56       0       0       0 |      56       0 | runtime/interrupt
+    175       0       0       0 |     175       0 | runtime/volatile
+    430     108       0       0 |     538       0 | strings
+    176       0       0       0 |     176       0 | time
 ------------------------------- | --------------- | -------
-  14094   34447    1440    4168 |   49981    5608 | total
+  13925   34459    1440    4184 |   49824    5624 | total

--- a/examples/helloacetime/esp32.size.txt
+++ b/examples/helloacetime/esp32.size.txt
@@ -1,10 +1,10 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
       0       0       2       5 |       2       7 | (padding)
-   1383      16       0       0 |    1399       0 | (unknown)
+   1381      16       0       0 |    1397       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
      66       0       0       0 |      66       0 | device/esp
-   6188      31       0       0 |    6219       0 | github.com/bxparks/acetimego/acetime
+   6181      31       0       0 |    6212       0 | github.com/bxparks/acetimego/acetime
     212       0       0       0 |     212       0 | github.com/bxparks/acetimego/internal/strbuild
       0   34031    1438       0 |   35469    1438 | github.com/bxparks/acetimego/zonedb2000
    1823       0       0       0 |    1823       0 | github.com/bxparks/acetimego/zoneinfo
@@ -12,12 +12,12 @@
      37       0       0       0 |      37       0 | internal/stringslite
     310      24       0       8 |     334       8 | internal/task
       9       0       0       0 |       9       0 | machine
-    313      77       0       0 |     390       0 | main
+    316      77       0       0 |     393       0 | main
      10       0       0       0 |      10       0 | math/bits
-   2678     172       0      75 |    2850      75 | runtime
+   2675     172       0      75 |    2847      75 | runtime
      56       0       0       0 |      56       0 | runtime/interrupt
-    175       0       0       0 |     175       0 | runtime/volatile
+    181       0       0       0 |     181       0 | runtime/volatile
     430     108       0       0 |     538       0 | strings
-    176       0       0       0 |     176       0 | time
+    171       0       0       0 |     171       0 | time
 ------------------------------- | --------------- | -------
-  13925   34459    1440    4184 |   49824    5624 | total
+  13917   34459    1440    4184 |   49816    5624 | total

--- a/examples/leapsecond/esp32.size.txt
+++ b/examples/leapsecond/esp32.size.txt
@@ -1,28 +1,30 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0      10       0       9 |      10       9 | (padding)
-   2979     868       0       0 |    3847       0 | (unknown)
+      0      11       0       9 |      11       9 | (padding)
+   2858     899       0       0 |    3757       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
-     89       0       0       0 |      89       0 | Go interface method
-      0     288       0       0 |     288       0 | Go types
+     12       0       0       0 |      12       0 | Go interface method
+      0     280       0       0 |     280       0 | Go types
      66       0       0       0 |      66       0 | device/esp
      13       0       0       0 |      13       0 | errors
-   6332      28       0       0 |    6360       0 | github.com/bxparks/acetimego/acetime
-    222       0       0       0 |     222       0 | github.com/bxparks/acetimego/internal/strbuild
-    190       0       0       0 |     190       0 | github.com/bxparks/acetimego/zoneinfo
+   6185      28       0       0 |    6213       0 | github.com/bxparks/acetimego/acetime
+    224       0       0       0 |     224       0 | github.com/bxparks/acetimego/internal/strbuild
+    182       0       0       0 |     182       0 | github.com/bxparks/acetimego/zoneinfo
      57       0       0       0 |      57       0 | internal/bytealg
-    142       2       0       0 |     144       0 | internal/itoa
-    349      24       0       8 |     373       8 | internal/task
-     20       0       0       0 |      20       0 | machine
-    795     134       0       0 |     929       0 | main
-   3850     591       0       0 |    4441       0 | reflect
-   3186     213       0      47 |    3399      47 | runtime
-     78       0       0       0 |      78       0 | runtime/interrupt
-    101       0       0       0 |     101       0 | runtime/volatile
-    515     108       0       0 |     623       0 | strings
-    167      38       0       0 |     205       0 | sync
+    161       2       0       0 |     163       0 | internal/itoa
+   4094     590      48       0 |    4732      48 | internal/reflectlite
+     37       0       0       0 |      37       0 | internal/stringslite
+    400      62       0       8 |     462       8 | internal/task
+      9       0       0       0 |       9       0 | machine
+    813     137       0       0 |     950       0 | main
+     19       0       0       0 |      19       0 | math/bits
+   3360     213       0      63 |    3573      63 | runtime
+     79       0       0       0 |      79       0 | runtime/interrupt
+    107       0       0       0 |     107       0 | runtime/volatile
+    439     108       0       0 |     547       0 | strings
+    105       0       0       0 |     105       0 | sync
      32       6       0       0 |      38       0 | syscall
-   8678     586      64      76 |    9328     140 | time
-    384     288       0       0 |     672       0 | unicode/utf8
+   8002     532      64      76 |    8598     140 | time
+    368     288       0       0 |     656       0 | unicode/utf8
 ------------------------------- | --------------- | -------
-  28245    3184      64    4236 |   31493    4300 | total
+  27622    3156     112    4252 |   30890    4364 | total

--- a/examples/leapsecond/esp32.size.txt
+++ b/examples/leapsecond/esp32.size.txt
@@ -7,9 +7,9 @@
       0     280       0       0 |     280       0 | Go types
      66       0       0       0 |      66       0 | device/esp
      13       0       0       0 |      13       0 | errors
-   6185      28       0       0 |    6213       0 | github.com/bxparks/acetimego/acetime
+   6180      28       0       0 |    6208       0 | github.com/bxparks/acetimego/acetime
     224       0       0       0 |     224       0 | github.com/bxparks/acetimego/internal/strbuild
-    182       0       0       0 |     182       0 | github.com/bxparks/acetimego/zoneinfo
+    179       0       0       0 |     179       0 | github.com/bxparks/acetimego/zoneinfo
      57       0       0       0 |      57       0 | internal/bytealg
     161       2       0       0 |     163       0 | internal/itoa
    4094     590      48       0 |    4732      48 | internal/reflectlite
@@ -27,4 +27,4 @@
    8002     532      64      76 |    8598     140 | time
     368     288       0       0 |     656       0 | unicode/utf8
 ------------------------------- | --------------- | -------
-  27622    3156     112    4252 |   30890    4364 | total
+  27614    3156     112    4252 |   30882    4364 | total

--- a/examples/leapsecond/tiny.size.txt
+++ b/examples/leapsecond/tiny.size.txt
@@ -1,31 +1,31 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
       0      26       4      14 |      30      18 | (padding)
-     28   22063      20    1043 |   22111    1063 | (unknown)
-   1438    3420       0      28 |    4858      28 | /usr/local/go/src/syscall
-  26499    3617     872  118017 |   30988  118889 | C bdwgc
-  16680    3025      12     576 |   19717     588 | C musl
+     28   22063      20    1027 |   22111    1047 | (unknown)
+   1438    3451       0      28 |    4889      28 | /usr/local/go/src/syscall
+  26499    3616     872  118017 |   30987  118889 | C bdwgc
+  16680    3026      12     576 |   19718     588 | C musl
     126       0       0       0 |     126       0 | Go interface assert
      96       0       0       0 |      96       0 | Go interface method
       0     472       0       0 |     472       0 | Go types
      43       0       0       0 |      43       0 | errors
-   7174      28       0       0 |    7202       0 | github.com/bxparks/acetimego/acetime
+   7180      28       0       0 |    7208       0 | github.com/bxparks/acetimego/acetime
     301       0       0       0 |     301       0 | github.com/bxparks/acetimego/internal/strbuild
-    166       0       0       0 |     166       0 | github.com/bxparks/acetimego/zoneinfo
+    171       0       0       0 |     171       0 | github.com/bxparks/acetimego/zoneinfo
     170       0       0       0 |     170       0 | internal/bytealg
     167       0       0       0 |     167       0 | internal/futex
     160       2       0       0 |     162       0 | internal/itoa
    4912     622      96       0 |    5630      96 | internal/reflectlite
      39       0       0       0 |      39       0 | internal/stringslite
     544      50       8      96 |     602     104 | internal/task
-   1044     134       0       0 |    1178       0 | main
+   1044     137       0       0 |    1181       0 | main
      27       0       0       0 |      27       0 | math/bits
    5535     324       4      26 |    5863      30 | runtime
-    531     124       0       0 |     655       0 | strings
+    535     124       0       0 |     659       0 | strings
     795      33       0       0 |     828       0 | sync
      90       0       0       0 |      90       0 | sync/atomic
-    201    1658      40      25 |    1899      65 | syscall
-  17557     902     184     112 |   18643     296 | time
+    201    1627      40      25 |    1868      65 | syscall
+  17557     899     184     112 |   18640     296 | time
     377     288       0       0 |     665       0 | unicode/utf8
 ------------------------------- | --------------- | -------
-  84700   36788    1240  119937 |  122728  121177 | total
+  84715   36788    1240  119921 |  122743  121161 | total

--- a/examples/leapsecond/tiny.size.txt
+++ b/examples/leapsecond/tiny.size.txt
@@ -1,27 +1,31 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0      34       4      14 |      38      18 | (padding)
-     27   12373      12      54 |   12412      66 | (unknown)
-   1576    3703       0      72 |    5279      72 | /usr/local/go/src/syscall
-   3850      58      12     536 |    3920     548 | C musl
-    284       0       0       0 |     284       0 | Go interface assert
-     29       0       0       0 |      29       0 | Go interface method
-      0     696       0       0 |     696       0 | Go types
+      0      26       4      14 |      30      18 | (padding)
+     28   22063      20    1043 |   22111    1063 | (unknown)
+   1438    3420       0      28 |    4858      28 | /usr/local/go/src/syscall
+  26499    3617     872  118017 |   30988  118889 | C bdwgc
+  16680    3025      12     576 |   19717     588 | C musl
+    126       0       0       0 |     126       0 | Go interface assert
+     96       0       0       0 |      96       0 | Go interface method
+      0     472       0       0 |     472       0 | Go types
      43       0       0       0 |      43       0 | errors
-   7305      31       0       0 |    7336       0 | github.com/bxparks/acetimego/acetime
-    295       0       0       0 |     295       0 | github.com/bxparks/acetimego/internal/strbuild
-    171       0       0       0 |     171       0 | github.com/bxparks/acetimego/zoneinfo
-     80       0       0       0 |      80       0 | internal/bytealg
-    155       2       0       0 |     157       0 | internal/itoa
-    479      24       0      16 |     503      16 | internal/task
-    882     134       0       0 |    1016       0 | main
-   4819     622       0       0 |    5441       0 | reflect
-   6714     243      12      91 |    6969     103 | runtime
-    665     124       0       0 |     789       0 | strings
-    628     200       0       0 |     828       0 | sync
-     90      75       0       1 |     165       1 | sync/atomic
-    202    1379       0       0 |    1581       0 | syscall
-  18015     938     168     128 |   19121     296 | time
-    319     288       0       0 |     607       0 | unicode/utf8
+   7174      28       0       0 |    7202       0 | github.com/bxparks/acetimego/acetime
+    301       0       0       0 |     301       0 | github.com/bxparks/acetimego/internal/strbuild
+    166       0       0       0 |     166       0 | github.com/bxparks/acetimego/zoneinfo
+    170       0       0       0 |     170       0 | internal/bytealg
+    167       0       0       0 |     167       0 | internal/futex
+    160       2       0       0 |     162       0 | internal/itoa
+   4912     622      96       0 |    5630      96 | internal/reflectlite
+     39       0       0       0 |      39       0 | internal/stringslite
+    544      50       8      96 |     602     104 | internal/task
+   1044     134       0       0 |    1178       0 | main
+     27       0       0       0 |      27       0 | math/bits
+   5535     324       4      26 |    5863      30 | runtime
+    531     124       0       0 |     655       0 | strings
+    795      33       0       0 |     828       0 | sync
+     90       0       0       0 |      90       0 | sync/atomic
+    201    1658      40      25 |    1899      65 | syscall
+  17557     902     184     112 |   18643     296 | time
+    377     288       0       0 |     665       0 | unicode/utf8
 ------------------------------- | --------------- | -------
-  46628   20924     208     912 |   67760    1120 | total
+  84700   36788    1240  119937 |  122728  121177 | total

--- a/examples/timezonespecial/esp32.size.txt
+++ b/examples/timezonespecial/esp32.size.txt
@@ -1,16 +1,16 @@
    code  rodata    data     bss |   flash     ram | package
 ------------------------------- | --------------- | -------
-      0       0       0       6 |       0       6 | (padding)
-    558       0       0       0 |     558       0 | (unknown)
+      0       0       0       5 |       0       5 | (padding)
+    524      16       0       0 |     540       0 | (unknown)
       0       0       0    4096 |       0    4096 | C stack
      66       0       0       0 |      66       0 | device/esp
      13       0       0       0 |      13       0 | github.com/bxparks/acetimego/acetime
      24       0       0       0 |      24       0 | github.com/bxparks/acetimego/zoneinfo
-    300      24       0       8 |     324       8 | internal/task
-     20       0       0       0 |      20       0 | machine
+    289      24       0       8 |     313       8 | internal/task
+      9       0       0       0 |       9       0 | machine
     135      64       0       0 |     199       0 | main
-   1550     119       0      46 |    1669      46 | runtime
-     55       0       0       0 |      55       0 | runtime/interrupt
-    101       0       0       0 |     101       0 | runtime/volatile
+   1638     119       0      63 |    1757      63 | runtime
+     56       0       0       0 |      56       0 | runtime/interrupt
+    107       0       0       0 |     107       0 | runtime/volatile
 ------------------------------- | --------------- | -------
-   2822     207       0    4156 |    3029    4156 | total
+   2861     223       0    4172 |    3084    4172 | total


### PR DESCRIPTION
- 0.9.0 (2025-11-17, TZDB 2025b)
    - **Breaking** Replace  `ZonedExtra.FoldType` with `ZonedExtra.Resolved`
      which has the same meaning as `ZonedDateTime.Resolved`.
    - **Breaking** Use typesafe types for enums (`findResultType` instead of
      `uint8`, `ResolvedType` instead of `uint8`).
    - **Breaking** Remove `ZonedDataTime.ZonedExtra()` that converts
      `ZonedDateTime` into a `ZonedExtra`.
        - Use `ZonedExtraFromPlainDateTime()` or `ZonedExtraFromUnixSeconds()`
          instead.
        - For compatibility with `AceTime` and `acetimec` libraries. Simplifies
          the API.
